### PR TITLE
Rails MarkIt 5: Bookmarks crud

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -21,10 +21,36 @@ class BookmarksController < ApplicationController
   end
 
   def edit
+    @bookmark = Bookmark.find(params[:id])
   end
-end
 
-private
-def bookmark_params
-  params.require(:bookmark).permit(:url)
+  def update
+    @bookmark = Bookmark.find(params[:id])
+    @bookmark.assign_attributes(bookmark_params)
+
+    if @bookmark.save
+      flash[:notice] = "Bookmark was updated successfully."
+      redirect_to [@bookmark.topic]
+    else
+      flash.now[:alert] = "There was an error saving the post. Please try again."
+      render :edit
+    end
+  end
+
+  def destroy
+    @bookmark = Bookmark.find(params[:id])
+
+    if @bookmark.destroy
+      flash[:notice] = "\"#{@bookmark.url}\" was deleted successfully."
+      redirect_to topics_path
+    else
+      flash.now[:alert] = "There was an error deleting the bookmark."
+      render :show
+    end
+  end
+
+  private
+  def bookmark_params
+    params.require(:bookmark).permit(:url)
+  end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -3,8 +3,28 @@ class BookmarksController < ApplicationController
   end
 
   def new
+    @topic = Topic.find(params[:topic_id])
+    @bookmark = Bookmark.new
+  end
+
+  def create
+    @topic = Topic.find(params[:topic_id])
+    @bookmark = @topic.bookmarks.build(bookmark_params)
+
+    if @bookmark.save
+      flash[:notice] = "Bookmark was saved successfully."
+    else
+      flash.now[:alert] = "There was an error saving the bookmark. Please try again."
+    end
+
+    redirect_to @topic
   end
 
   def edit
   end
+end
+
+private
+def bookmark_params
+  params.require(:bookmark).permit(:url)
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -42,7 +42,7 @@ class BookmarksController < ApplicationController
 
     if @bookmark.destroy
       flash[:notice] = "\"#{@bookmark.url}\" was deleted successfully."
-      redirect_to topics_path
+      redirect_to [@bookmark.topic]
     else
       flash.now[:alert] = "There was an error deleting the bookmark."
       render :show

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,11 +1,14 @@
 class TopicsController < ApplicationController
 
   def index
+    @user = current_user
     @topics = Topic.all
+    @bookmarks = Bookmark.all
   end
 
   def show
     @topic = Topic.find(params[:id])
+    @bookmarks = @topic.bookmarks
   end
 
   def new

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,3 +1,6 @@
 class Bookmark < ApplicationRecord
   belongs_to :topic
+
+  validates :topic, presence: true
+  validates :url, presence: true
 end

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -1,2 +1,12 @@
-<p><%= link_to "#{bookmark.url}", bookmark.url %></p>
-<br />
+<p><%= link_to "#{bookmark.url}", bookmark.url %>&nbsp;&nbsp;
+  <%= link_to edit_topic_bookmark_path(@topic, bookmark) do %>
+    <span style = "font-size: 11pt">
+      <span class='has-tooltip' data-toggle='tooltip' title='Edit Bookmark'>
+        <span class = 'glyphicon glyphicon-pencil'></span>
+      </span>
+    </span>
+  <% end %>
+
+
+  <br />
+</p>

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -1,0 +1,2 @@
+<p><%= link_to "#{bookmark.url}", bookmark.url %></p>
+<br />

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -6,7 +6,13 @@
       </span>
     </span>
   <% end %>
-
-
+  &nbsp;
+  <%= link_to [@topic, bookmark], method: :delete, data: { confirm: 'Are you sure you want to delete this post?' } do %>
+  <span style = "font-size: 11pt">
+    <span class='has-tooltip' data-toggle='tooltip' title='Delete Bookmark'>
+      <span class = 'glyphicon glyphicon-trash'></span>
+    </span>
+  </span>
+  <% end %>
   <br />
 </p>

--- a/app/views/bookmarks/edit.html.erb
+++ b/app/views/bookmarks/edit.html.erb
@@ -1,2 +1,8 @@
-<h1>Bookmarks#edit</h1>
-<p>Find me in app/views/bookmarks/edit.html.erb</p>
+<h2>Edit Bookmark</h2>
+<%= form_for [@bookmark.topic, @bookmark] do |f| %>
+    <div class = 'form-group'>
+      <%= f.text_field :url, class: 'form-control', placeholder: "Enter URL" %>
+      <br />
+      <%= f.submit "Save", class: 'btn btn-success' %>&nbsp;&nbsp;<%= link_to "Cancel", :back %>
+    </div>
+<% end %>

--- a/app/views/bookmarks/new.html.erb
+++ b/app/views/bookmarks/new.html.erb
@@ -1,4 +1,4 @@
-<h2>New Topic</h2>
+<h2>New Bookmark</h2>
 
 <%= form_for [@topic, @bookmark] do |f| %>
   <div class = 'form-group'>

--- a/app/views/bookmarks/new.html.erb
+++ b/app/views/bookmarks/new.html.erb
@@ -1,2 +1,9 @@
-<h1>Bookmarks#new</h1>
-<p>Find me in app/views/bookmarks/new.html.erb</p>
+<h2>New Topic</h2>
+
+<%= form_for [@topic, @bookmark] do |f| %>
+  <div class = 'form-group'>
+    <%= f.text_field :url, class: 'form-control', placeholder: "Enter url" %>
+    <br />
+    <%= f.submit "Save", class: 'btn btn-success' %>&nbsp;&nbsp;<%= link_to "Cancel", :back %>
+  </div>
+<% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,42 +2,44 @@
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
+  Before making any changes, please provide your current password.<br /><br />
 
-  <div class="field">
+  <div class="form-group">
+    <%= f.label :current_password %><br />
+    <%= f.password_field :current_password, autocomplete: "off", class: 'form-control', placeholder: 'Current Password' %>
+  </div>
+  <hr />
+
+  <div class="form-group">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email' %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
+  <div class="form-group">
+    <%= f.label :new_password %>&nbsp;&nbsp;(
     <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <%= @minimum_password_length %> characters minimum.
     <% end %>
+     Leave blank if you don't want to change it.)<br />
+    <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password' %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  <div class="form-group">
+    <%= f.label :new_password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm New Password' %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %>
-  </div>
+
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "Update", class: 'btn btn-primary' %>&nbsp;&nbsp;<%= link_to "Cancel", :back %>
   </div>
 <% end %>
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<p>Need a break from organizing? Click 'Cancel Account' button below to remove your profile. This will delete all your bookmarks. <%= button_to "Cancel my account", registration_path(resource_name), class: 'btn btn-danger', data: { confirm: "Are you sure?" }, method: :delete %></p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,15 +1,23 @@
 <div class = 'container'>
-  <div class = 'row'>
-    <%= link_to "+ New Topic", new_topic_path, class: 'btn btn-default' %>
+  <div class = 'col-md-8'>
+    <div class = 'row'>
+      <div class = 'col-md-8'>
+        <% @topics.each do |topic| %>
+          <h4>
+            # <%= link_to topic.title, topic %>
+            <br />
+          </h4>
+          <!-- unsure why bookmarks are not displaying -->
+          <% if @bookmarks.present? %>
+            <%= render partial: 'bookmarks/bookmark', collection: @bookmarks, locals: { topic: topic } %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
   </div>
-  <div class = 'row'>
-    <div class = 'col-md-8'>
-      <% @topics.each do |topic| %>
-        <h4>
-          # <%= link_to topic.title, topic %>
-          <br />
-        </h4>
-      <% end %>
+  <div class = 'col-md-4'>
+    <div class = 'row'>
+      <%= link_to "+ New Topic", new_topic_path, class: 'btn btn-primary' %>
     </div>
   </div>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,7 +15,7 @@
   <h4>
     <% if @bookmarks.present? %>
       <br />
-      <%= render partial: 'bookmarks/bookmark', collection: @bookmarks, locals: { topic_id: @topic.id } %>
+      <%= render partial: 'bookmarks/bookmark', collection: @bookmarks, locals: { topic_id: @topic.id, bookmark: @bookmark} %>
     <% end %>
   </h4>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,3 +1,24 @@
-<h2>#<%= @topic.title %></h2>
-<%= link_to "Edit Topic", edit_topic_path %> |
-<%= link_to "Delete Topic", @topic, method: :delete, data: { confirm: 'Are you sure you want to delete this topic?' }%>
+<div class='col-md-8'>
+  <span style = 'font-size:18pt'><strong>#<%= @topic.title %></strong></span>&nbsp;&nbsp;
+    <%= link_to edit_topic_path do %>
+      <span class='has-tooltip' data-toggle='tooltip' title='Edit Topic'>
+        <span class = 'glyphicon glyphicon-pencil'></span>
+    <% end %>
+    &nbsp;
+    <%= link_to @topic, method: :delete, data: { confirm: 'Are you sure you want to delete this topic?' } do %>
+      <span class="has-tooltip" data-toggle="tooltip" title="Delete Topic">
+          <span class="glyphicon glyphicon-trash"></span>
+      </span>
+    <% end %>
+  </h2>
+
+  <h4>
+    <% if @bookmarks.present? %>
+      <br />
+      <%= render partial: 'bookmarks/bookmark', collection: @bookmarks, locals: { topic_id: @topic.id } %>
+    <% end %>
+  </h4>
+</div>
+<div class = 'col-md-4'>
+  <%= link_to "New Bookmark", new_topic_bookmark_path(@topic), class: 'btn btn-primary' %>
+</div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,16 +5,32 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+# Create user
+User.create!(
+  email: 'member@markit.com',
+  password: 'helloworld',
+  confirmed_at: '2016-08-14'
+)
+users = User.all
 
 # Create Topics
-15.times do
+5.times do
   Topic.create!(
     title: Faker::Lorem.word,
-    user_id: 1
+    user: users.sample
   )
 end
 topics = Topic.all
 
-
+# Create Bookmarks
+15.times do
+  bookmark = Bookmark.create!(
+    topic: topics.sample,
+    url: Faker::Internet.url
+  )
+  bookmark.update_attribute(:created_at, rand(10.minutes .. 1.year).ago)
+end
+bookmarks = Bookmark.all
 
 puts "#{Topic.count} topics created"
+puts "#{Bookmark.count} bookmarks created"

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -41,10 +41,30 @@ RSpec.describe BookmarksController, type: :controller do
   end
 
   describe "GET #edit" do
-    it "returns http success" do
-      get :edit
+    it "returns http redirect" do
+      get :edit, topic_id: @my_topic.id, id: @bookmark.id
       expect(response).to have_http_status(:success)
     end
   end
 
+  describe "PUT update" do
+    it "returns http redirect" do
+      url = Faker::Internet.url
+      put :update, topic_id: @my_topic.id, id: @bookmark.id, bookmark: {url: url}
+      expect(response).to redirect_to(@my_topic)
+    end
+  end
+
+  describe "DELETE destroy" do
+    it "deletes the bookmark" do
+      delete :destroy, topic_id: @my_topic.id, id: @bookmark.id
+      count = Bookmark.where({id: @bookmark.id}).size
+      expect(count).to eq 0
+    end
+
+    it "redirects to topic" do
+      delete :destroy, topic_id: @my_topic.id, id: @bookmark.id
+      expect(response).to redirect_to topics_path
+    end
+  end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe BookmarksController, type: :controller do
 
     it "redirects to topic" do
       delete :destroy, topic_id: @my_topic.id, id: @bookmark.id
-      expect(response).to redirect_to topics_path
+      expect(response).to redirect_to(@my_topic)
     end
   end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe BookmarksController, type: :controller do
+  before do
+    @user = User.create!(email: 'member@example.com', password: 'helloworld', password_confirmation: 'helloworld')
+    @user.confirm
+    sign_in @user
+    @my_topic = Topic.create!(title: Faker::Lorem.word, user: @user)
+    @bookmark = Bookmark.create!(url: Faker::Internet.url, topic: @my_topic)
+  end
 
   describe "GET #show" do
     it "returns http success" do
@@ -11,8 +18,25 @@ RSpec.describe BookmarksController, type: :controller do
 
   describe "GET #new" do
     it "returns http success" do
-      get :new
+      get :new, topic_id: @my_topic.id
       expect(response).to have_http_status(:success)
+    end
+
+    it "renders the #new view" do
+        get :new, topic_id: @my_topic.id
+        expect(response).to render_template :new
+      end
+
+    it "instantiates @bookmark" do
+      post :create, topic_id: @my_topic.id, bookmark: { url: Faker::Internet.url }
+      expect(assigns(:bookmark)).not_to be_nil
+    end
+  end
+
+  describe "POST create" do
+    it "returns http redirect" do
+      post :create, topic_id: @my_topic.id, bookmark: { url: Faker::Internet.url }
+      expect(response).to redirect_to(@my_topic)
     end
   end
 

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :bookmark do
-    url "MyString"
-    topic nil
+    url { Faker::Internet.url }
+    topic
   end
 end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Bookmark, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:email) { Faker::Internet.email }
+  let(:user) { User.create!(email: email, password: 'helloworld') }
+  let(:title) { Faker::Lorem.word }
+  let(:topic) { Topic.create!(title: title, user: user) }
+  let(:url) { Faker::Internet.url }
+  let(:bookmark) { Bookmark.create!(url: url, topic: topic) }
+
+  it {is_expected.to belong_to(:topic)}
+
+  it { is_expected.to validate_presence_of(:url) }
+  it { is_expected.to validate_presence_of(:topic) }
+
+  describe "attributes" do
+    it "has url" do
+      expect(bookmark).to have_attributes(url: url)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
SimpleCov: All Files (93.6% covered at 1.57 hits/line)

Bookmarks are found by navigating to a topic after signing in. This is where the user is able to add, edit and delete them.
<img width="1167" alt="screen shot 2016-08-15 at 10 03 27 pm" src="https://cloud.githubusercontent.com/assets/9088480/17686680/317fafde-6334-11e6-8553-9829ef9bb255.png">

After clicking 'New Bookmark', the user is presented with a form.
<img width="1192" alt="screen shot 2016-08-15 at 10 15 43 pm" src="https://cloud.githubusercontent.com/assets/9088480/17686888/e4ce1098-6335-11e6-9a86-c15c7d4075e5.png">

Clicking the pencil next to the bookmark presents the 'New Bookmark' form but with the url of the selected bookmark pre-filled. Clicking the trash can presents a warning, the bookmark is deleted, and the user is returned to the topic page listing all the bookmarks.
<img width="420" alt="screen shot 2016-08-15 at 10 08 39 pm" src="https://cloud.githubusercontent.com/assets/9088480/17686769/ee92d5c4-6334-11e6-94a9-5c6319765109.png">

I also stylized the Edit Profile page.
<img width="1195" alt="screen shot 2016-08-15 at 10 10 56 pm" src="https://cloud.githubusercontent.com/assets/9088480/17686806/37f3b31e-6335-11e6-8bce-c07ab8096fe6.png">
